### PR TITLE
fix: add require 'stringio'

### DIFF
--- a/lib/ecies.rb
+++ b/lib/ecies.rb
@@ -1,4 +1,5 @@
 require 'openssl'
+require 'stringio'
 
 require 'ecies/crypt.rb'
 require 'ecies/version.rb'


### PR DESCRIPTION
Hi!
This PR would add "require 'stringio'". It is a dependent gem.

Thanks.


